### PR TITLE
Fix random breaking on round start and update exiled

### DIFF
--- a/WaitAndChillReborn/Handler.cs
+++ b/WaitAndChillReborn/Handler.cs
@@ -152,41 +152,38 @@
         internal void OnRoundStarted()
         {
             SubClassHandler(true);
-
-            Timing.CallDelayed(0.25f, () =>
+            
+            foreach (Player ply in Player.List)
             {
-                foreach (Player ply in Player.List)
+                if (!Config.AllowDamage)
                 {
-                    if (!Config.AllowDamage)
-                    {
-                        ply.IsGodModeEnabled = false;
-                    }
-
-                    if (Config.ColaMultiplier != 0)
-                    {
-                        ply.DisableEffect<Scp207>();
-                    }
+                    ply.IsGodModeEnabled = false;
                 }
 
-                if (Config.TurnedPlayers)
+                if (Config.ColaMultiplier != 0)
                 {
-                    Scp096.TurnedPlayers.Clear();
-                    Scp173.TurnedPlayers.Clear();
+                    ply.DisableEffect<Scp207>();
                 }
+            }
 
-                foreach (var door in spawnedDoors)
-                {
-                    NetworkServer.Destroy(door.gameObject);
-                }
-                spawnedDoors.Clear();
+            if (Config.TurnedPlayers)
+            {
+                Scp096.TurnedPlayers.Clear();
+                Scp173.TurnedPlayers.Clear();
+            }
 
-                Scp079sDoors(false);
+            foreach (var door in spawnedDoors)
+            {
+                NetworkServer.Destroy(door.gameObject);
+            }
+            spawnedDoors.Clear();
 
-                if (lobbyTimer.IsRunning)
-                {
-                    Timing.KillCoroutines(lobbyTimer);
-                }
-            });
+            Scp079sDoors(false);
+
+            if (lobbyTimer.IsRunning)
+            {
+                Timing.KillCoroutines(lobbyTimer);
+            }
         }
     }
 }

--- a/WaitAndChillReborn/WaitAndChillReborn.csproj
+++ b/WaitAndChillReborn/WaitAndChillReborn.csproj
@@ -45,29 +45,40 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\C#\Stuff\Pluginy EXILED\Exiled Stuff\Exiled dll\CommandSystem.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Exiled.API, Version=2.10.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\EXILED.2.10.0-beta\lib\net472\Exiled.API.dll</HintPath>
+    <Reference Include="CommandSystem.Core, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\Desktop\Exiled\CommandSystem.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Exiled.Bootstrap, Version=2.10.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\EXILED.2.10.0-beta\lib\net472\Exiled.Bootstrap.dll</HintPath>
+    <Reference Include="Exiled.API, Version=2.11.1.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\EXILED.2.11.1\lib\net472\Exiled.API.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Exiled.CreditTags, Version=2.10.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\EXILED.2.10.0-beta\lib\net472\Exiled.CreditTags.dll</HintPath>
+    <Reference Include="Exiled.Bootstrap, Version=2.11.1.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\EXILED.2.11.1\lib\net472\Exiled.Bootstrap.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Exiled.CustomItems, Version=2.10.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\EXILED.2.10.0-beta\lib\net472\Exiled.CustomItems.dll</HintPath>
+    <Reference Include="Exiled.CreditTags, Version=2.11.1.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\EXILED.2.11.1\lib\net472\Exiled.CreditTags.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Exiled.Events, Version=2.10.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\EXILED.2.10.0-beta\lib\net472\Exiled.Events.dll</HintPath>
+    <Reference Include="Exiled.CustomItems, Version=2.11.1.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\EXILED.2.11.1\lib\net472\Exiled.CustomItems.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Exiled.Loader, Version=2.10.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\EXILED.2.10.0-beta\lib\net472\Exiled.Loader.dll</HintPath>
+    <Reference Include="Exiled.Events, Version=2.11.1.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\EXILED.2.11.1\lib\net472\Exiled.Events.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Exiled.Permissions, Version=2.10.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\EXILED.2.10.0-beta\lib\net472\Exiled.Permissions.dll</HintPath>
+    <Reference Include="Exiled.Loader, Version=2.11.1.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\EXILED.2.11.1\lib\net472\Exiled.Loader.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Exiled.Updater, Version=3.1.1.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\EXILED.2.10.0-beta\lib\net472\Exiled.Updater.dll</HintPath>
+    <Reference Include="Exiled.Permissions, Version=2.11.1.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\EXILED.2.11.1\lib\net472\Exiled.Permissions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Exiled.Updater, Version=3.1.1.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\EXILED.2.11.1\lib\net472\Exiled.Updater.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Mirror">
       <HintPath>..\..\..\C#\Stuff\Pluginy EXILED\Exiled Stuff\Exiled dll\Mirror.dll</HintPath>

--- a/WaitAndChillReborn/packages.config
+++ b/WaitAndChillReborn/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EXILED" version="2.10.0-beta" targetFramework="net472" />
+  <package id="EXILED" version="2.11.1" targetFramework="net472" />
   <package id="Lib.Harmony" version="2.0.4" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
Fixes issue where round starts and people are not spawned in breaking the round, requiring admin intervention.

This has been tested on my server for about 10 days with no reported issues and the problem fixed.

Removes the delay in OnRoundStarted()